### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/app_renault_mvp.py
+++ b/app_renault_mvp.py
@@ -4,7 +4,7 @@ import datetime
 import random
 import threading
 import time
-
+import os
 app = Flask(__name__)
 
 
@@ -96,4 +96,5 @@ if __name__ == "__main__":
     print("🌱 EcoCode.AI - Sustentabilidade Digital Renault")
     print("Acesse: http://localhost:5000")
     print("Sobre: http://localhost:5000/sobre")
-    app.run(debug=True, port=5000)
+    debug = os.environ.get('FLASK_DEBUG', '0') == '1'
+    app.run(debug=debug, port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/leonardobora/eco-dashboard-renault/security/code-scanning/1](https://github.com/leonardobora/eco-dashboard-renault/security/code-scanning/1)

To resolve this issue, the Flask app should not be run with `debug=True` hardcoded. The best solution is to allow debug mode to be enabled only in a safe, controlled way — typically by checking an environment variable (e.g., `FLASK_DEBUG`) or configuration setting. This ensures debug mode is never accidentally enabled in production.  

To implement this fix:
- Remove the explicit `debug=True` parameter from `app.run()`.
- Optionally, allow the developer to enable debug mode explicitly via the `FLASK_DEBUG` environment variable.
- If you want to keep the ability to use debug mode in development, you can import `os` and write logic such as:
  ```python
  debug = os.environ.get('FLASK_DEBUG', '0') == '1'
  app.run(debug=debug, port=5000)
  ```
- If simplicity is preferred (and you don’t want to allow debug mode at all from the script), just remove `debug=True` and call `app.run(port=5000)`.

**Changes:**
- Edit line 99.
- If needed, add an `import os` at the top.
- Use a `debug` variable controlled by an environment variable (optional).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
